### PR TITLE
Fix province code validator on root objects

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -46,7 +46,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
         /** @var ProvinceAddressConstraint $constraint */
         Assert::isInstanceOf($constraint, ProvinceAddressConstraint::class);
 
-        $propertyPath = $this->context->getPropertyPath();
+        $propertyPath = $this->context->getPropertyPath('provinceCode');
 
         foreach (iterator_to_array($this->context->getViolations()) as $violation) {
             if (0 === strpos($violation->getPropertyPath(), $propertyPath)) {


### PR DESCRIPTION
when the validator is used to validate root objects, `$this->context->getPropertyPath()` returns empty string.
This makes `strpos` throw error as it does not take empty string as 2nd argument

| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
